### PR TITLE
feat: 개발 서버와 배포 서버의 로그인 페이지 분리 main에 병합

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,19 +14,23 @@ import UserPrivacyPage from './pages/TermPage/UserPrivacyPage';
 import UsePolicyPage from './pages/TermPage/UsePolicyPage';
 import BottomNavi from './components/BottomNavi/BottomNavi';
 import AuthProvider from './contexts/AuthProvider';
+import LoginPage from './pages/LoginPage';
 
 const queryClient = new QueryClient();
 
 function AppContent() {
   const location = useLocation();
+  const isDev = import.meta.env.DEV;
+
   const showBottomNavi =
-    location.pathname === '/' || location.pathname === '/PlusPage';
+    (!isDev && location.pathname === '/') || location.pathname === '/PlusPage';
+
   return (
     <div
       className={`w-full flex flex-col ${showBottomNavi ? 'min-h-[calc(100vh - 86px)]' : 'min-h-screen'}`}
     >
       <Routes>
-        <Route path="/" element={<SchedulePage />} />
+        <Route path="/" element={isDev ? <LoginPage /> : <SchedulePage />} />
         <Route path="/PlusPage" element={<PlusPage />} />
         <Route path="/info/usePolicy" element={<UsePolicyPage />} />
         <Route path="/info/privacy" element={<UserPrivacyPage />} />

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -22,7 +22,7 @@ const TextField: React.FC<TextFieldProps> = ({ postSchedule }) => {
       <div className={'w-full relative'}>
         <input
           className={
-            ' w-full px-[1.0625rem] py-[0.8125rem] pr-[3.6rem] outline-none text-Grey_06 body_03 bg-Grey_02 rounded-15 focus:border-1 focus:border-Grey_06 placeholder:text-Grey_04 placeholder:text-14'
+            ' w-full px-[1.0625rem] py-[0.8125rem] pr-[3.6rem] outline-none border border-transparent text-Grey_06 body_03 bg-Grey_02 rounded-15 focus:border-1 focus:border-Grey_06 placeholder:text-Grey_04 placeholder:text-14'
           }
           type="text"
           placeholder="예 ) 오늘 오후 7시 팀플 회의"

--- a/src/index.css
+++ b/src/index.css
@@ -29,11 +29,17 @@
     }
 
     .body_04 {
-        @apply text-13 leading-[1rem];
+        @apply text-13 leading-[1rem] font-semibold;
     }
 
     .body_05 {
         @apply text-13 leading-[150%];
+    }
+    .Content_01{
+        @apply text-17 leading-[150%];
+    }
+    .Content_02{
+        @apply text-15 leading-[150%];
     }
 }
 

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,0 +1,21 @@
+import { api } from '../../utils/axios';
+
+export default function LoginPage() {
+  const onClickHandler = async () => {
+    console.log('clicked');
+    try {
+      const response = await api.post('/oauth/qa');
+      console.log(response.data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <button className="border" onClick={onClickHandler}>
+        로그인버튼
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용

- 기타 환경 변수 및 조건 설정 정리 (import.meta.env.MODE활용)

- 개발용 로그인 페이지 UI 구성 (/)

- 개발 환경에서만 해당 페이지 접근 가능하도록 조건 분기

- 실제 페이지 진입 후 메인 페이지로 이동하도록 라우팅 처리

- QA 로그인 API 연결
- textfield 관련 디자인 QA 완료

---
## ⚠️ 참고 사항
- 제대로 작동하는지는 배포를 해야해서 아직 확인은 못했습니다.
- 버튼 클릭 이후, API 연결 동작까진 구현 완료했으나 로그인 API 관련 로직(기존의 Context API와 axios interceptor 관련) 은 다음 PR 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new login page with a button that initiates an authentication request.
- **Style**
	- Updated input fields to always include a transparent border for improved focus styling.
	- Enhanced typography with new font weight and additional utility classes for content styling.
- **Other**
	- The login page is now shown by default in development mode, with navigation visibility adjusted accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->