### PR TITLE
fix: schedule counts가 403으로 인해 undefined일 때 오류 발생

### DIFF
--- a/src/pages/SchedulePage/Calendar/index.tsx
+++ b/src/pages/SchedulePage/Calendar/index.tsx
@@ -91,7 +91,7 @@ const Calendar = ({
             const isSelected = selectedDate?.isSame(day, 'day');
 
             const currentDateStr = day.format('YYYY-MM-DD');
-            const matchingData = weeklyScheduleData.find(item => item.date === currentDateStr);
+            const matchingData = weeklyScheduleData?.find(item => item.date === currentDateStr);
             const count = matchingData?.counts ?? null;
             const status = matchingData?.status ?? null;
 


### PR DESCRIPTION
## 📌 개요
schedule counts가 403으로 인해 undefined일 때 오류 발생 해결

---

## ✅ 작업 내용
```
            const matchingData = weeklyScheduleData?.find(item => item.date === currentDateStr);

```
체이닝 연산자로 해결하려고 합니다.

---

## ⚠️ 참고 사항
- 해당 이슈는 prod 환경에서만 확인 가능한 부분이므로, 배포 후 실제 동작을 검증할 필요가 있습니다.
- 
- 현재 앱의 인증 로직은 다음과 같은 흐름으로 구성되어 있습니다:
1. 사용자가 API 요청을 보냈을 때 access token이 만료되어 403 에러가 발생하면
2. 서버가 새로운 access token을 응답으로 내려주고
3. 클라이언트에서는 이를 axios 인터셉터에서 감지하여 localStorage에 저장한 뒤, 실패했던 요청을 다시 시도합니다.

한편, 이와 별도로 앱이 실행되자마자 Context API를 활용해 사용자의 인증 상태를 확인하고 전역 상태로 관리하는 구조를 사용 중입니다.

이번 오류는 이 구조에서 발생한 문제로,
앱 초기 단계에서 별도의 인증 확인 로직 없이 곧바로 비즈니스 로직(API 호출 등)을 실행하면서 인증 흐름이 꼬이고 예기치 않은 동작이 발생하게 된 것입니다.

따라서, 현재 구조를 일부 수정하고, 앱 초기 진입 시 사용자 인증 상태를 먼저 확인하는 전용 API 호출이 선행되어야 할 필요가 있다고 판단하고 있습니다.
