### PR TITLE
refactor: 렌더링 최적화

### DIFF
--- a/src/components/AddPageContainer/AddPageContainer.tsx
+++ b/src/components/AddPageContainer/AddPageContainer.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import rightArrow from '../../assets/images/rightArrow.svg';
 
@@ -7,7 +8,7 @@ type Props = {
   onClick?: () => void;
 };
 
-const AddPageContainer = ({ title, contentTitles, onClick }: Props) => {
+const AddPageContainer = ({ title, contentTitles }: Props) => {
   const navigate = useNavigate();
 
   const onClickHandler = (contentTitle: string) => {
@@ -45,10 +46,7 @@ const AddPageContainer = ({ title, contentTitles, onClick }: Props) => {
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Title */}
       <div className="body_05">{title}</div>
-
-      {/* Content Title List */}
       <div className="flex flex-col gap-[1.6875rem]">
         {contentTitles.map((contentTitle, index) => (
           <div

--- a/src/components/ScheduleCard/ScheduleCard.tsx
+++ b/src/components/ScheduleCard/ScheduleCard.tsx
@@ -6,17 +6,16 @@ import BottomSheet from '../BottomSheet/BottomSheet';
 import useScheduleListQuery from '../../hooks/useScheduleListQuery';
 import DefaultComponent from '../../pages/SchedulePage/DefaultComponent';
 
-import { Dayjs } from 'dayjs';
 import useSchedule from '../../hooks/useScheduleMutation';
 
 type ScheduleCardProps = {
-  selectedDate: Dayjs;
+  selectedDate: string;
 };
 
 const ScheduleCard = ({ selectedDate }: ScheduleCardProps) => {
-  const year = selectedDate.year();
-  const month = selectedDate.month() + 1;
-  const day = selectedDate.date();
+  const year = selectedDate.split('-')[0];
+  const month = selectedDate.split('-')[1];
+  const day = selectedDate.split('-')[2];
 
   const { data: scheduleList = [] } = useScheduleListQuery(year, month, day);
   const  { deleteSchedule } = useSchedule();
@@ -40,6 +39,8 @@ const ScheduleCard = ({ selectedDate }: ScheduleCardProps) => {
       deleteSchedule(clickedSchedule);
     }
   };
+
+
 
   return (
     <div className="flex flex-col w-full h-full no-scrollbar flex-shrink-0 gap-6 bg-White rounded-[1.7rem] overflow-y-scroll">
@@ -72,4 +73,4 @@ const ScheduleCard = ({ selectedDate }: ScheduleCardProps) => {
   );
 };
 
-export default ScheduleCard;
+export default React.memo(ScheduleCard);

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -59,4 +59,4 @@ const TextField = () => {
 );
 };
 
-export default TextField;
+export default React.memo(TextField);

--- a/src/pages/SchedulePage/Calendar/index.tsx
+++ b/src/pages/SchedulePage/Calendar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import 'dayjs/locale/ko';
 import updateLocale from 'dayjs/plugin/updateLocale';
@@ -36,13 +36,8 @@ const Calendar = ({
       startOfWeek.add(idx, 'day'),
   );
 
-  const goToPreviousWeek = () => {
-    setSelectedDate(selectedDate.subtract(1, 'week'));
-  };
-
-  const goToNextWeek = () => {
-    setSelectedDate(selectedDate.add(1, 'week'));
-  };
+  const goToPreviousWeek = useCallback(() =>  setSelectedDate(selectedDate.subtract(1, 'week')), [])
+  const goToNextWeek = useCallback(() =>  setSelectedDate(selectedDate.add(1, 'week')), []);
 
   return (
       <div className="w-full">
@@ -60,7 +55,6 @@ const Calendar = ({
         <div className={'flex place-content-between'}>
           {days.map((day, idx) => {
             const isSelected = selectedDate?.isSame(day, 'day');
-
             const currentDateStr = day.format('YYYY-MM-DD');
             const matchingData = weeklyScheduleCounts?.find(item => item.date === currentDateStr);
             const count = matchingData?.counts ?? null;
@@ -94,4 +88,4 @@ const Calendar = ({
   );
 };
 
-export default Calendar;
+export default React.memo(Calendar);

--- a/src/pages/SchedulePage/index.tsx
+++ b/src/pages/SchedulePage/index.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import TextField from '../../components/TextField/TextField';
 import ScheduleCard from '../../components/ScheduleCard/ScheduleCard';
 import Calendar from './Calendar';
 
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 
 const SchedulePage = () => {
   const [selectedDate, setSelectedDate] = useState(dayjs());
+  const setDate = useCallback((date: Dayjs) => setSelectedDate(date), []);
 
   return (
     <div className="flex w-full flex-col px-18 h-screen no-scrollbar ">
@@ -18,12 +19,12 @@ const SchedulePage = () => {
         <div>
           <Calendar
             selectedDate={selectedDate}
-            setSelectedDate={setSelectedDate}
+            setSelectedDate={setDate}
           />
         </div>
       </div>
       <div className="flex-1 h-full overflow-y-auto">
-        <ScheduleCard selectedDate = {selectedDate} />
+        <ScheduleCard selectedDate = {selectedDate.format('YYYY-MM-DD')} />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 개요

React Profiler를 이용해 컴포넌트의 렌더링 속도를 측정하고 최적화 작업을 진행했습니다. 

---

## ✅ 작업 내용
- selectedDate의 영향을 받지 않았음에도 리렌더링 되던 TextField를 React.memo를 사용해 필요없는 렌더링을 막았습니다.
- SchedulePage가 리렌더링될 때마다 다른 함수 참조값이 넘어가서 
Calendar는 React.memo를 적용해도 무조건 리렌더링되던 문제를 useCallback을 이용해 함수의 참조값을 메모이제이션해 해결했습니다.
- dayjs 객체는 매번 새로운 참조를 만들기 때문에 React.memo에서 얕은 비교 (shallow)가 실패할 가능성이 높을 것이라고 생각했습니다. 따라서  .format(’YYYY-MM-DD’)를 사용해 명시적으로 비교가 가능하도록 넘겨주었습니다.

---

1. 최적화 전
<img width="438" height="328" alt="스크린샷 2025-07-18 오후 7 48 18" src="https://github.com/user-attachments/assets/4008816f-023d-4e52-9bf7-0c3a6646e52f" />

2. 최적화 후
<img width="396" height="331" alt="스크린샷 2025-07-18 오후 7 48 36" src="https://github.com/user-attachments/assets/dc895fcf-8283-46ec-8f61-10c6313ff0df" />

렌더링 속도를 7.3초에서 3.9초로 약 47% 개선할 수 있었습니다. 
---

더 자세한 작업 사항은 제 [티스토리](https://rimm.tistory.com/23) 에 작성했습니다!