### PR TITLE
fix: toggle-checked 이후 useWeeklyCalendar hook이 바로 불러지지 않는 현상 수정

### DIFF
--- a/src/hooks/useHandleChecked.ts
+++ b/src/hooks/useHandleChecked.ts
@@ -9,7 +9,7 @@ export const useHandleChecked = ({dailyDate, weekRangeDate} : UseSchedulesProps)
 
   return useMutation({
     mutationFn: async (scheduleId: number) => {
-      await api.post(`\`/schedules/${scheduleId}/actions/toggle-checked\``);
+      await api.post(`/schedules/${scheduleId}/actions/toggle-checked`);
     },
 
     onSuccess: () => {

--- a/src/pages/SchedulePage/Calendar/CalendarCell/index.tsx
+++ b/src/pages/SchedulePage/Calendar/CalendarCell/index.tsx
@@ -4,7 +4,6 @@ import selectedEmoji from '../../../../assets/images/Calendar/selectedEmoji.svg'
 import defaultEmoji from '../../../../assets/images/Calendar/defaultEmoji.svg';
 import CheckEmoji from '../../../../assets/images/check.svg?react';
 import { Dayjs } from 'dayjs';
-import { WeekData } from '../../../../types/weeklyCalendar';
 
 type Props = {
   day: Dayjs;

--- a/src/pages/SchedulePage/Calendar/CalendarCell/index.tsx
+++ b/src/pages/SchedulePage/Calendar/CalendarCell/index.tsx
@@ -10,15 +10,13 @@ type Props = {
   day: Dayjs;
   selectedDate: Dayjs;
   setSelectedDate: (date: Dayjs) => void;
-  matchingDate: WeekData;
+  status: string;
+  counts: number;
 };
 
-function CalendarCell({day, selectedDate, setSelectedDate, matchingDate} : Props) {
+function CalendarCell({day, selectedDate, setSelectedDate, status, counts} : Props) {
 
   const isSelected = selectedDate?.isSame(day, 'day');
-
-  const count = matchingDate?.counts ?? null;
-  const status = matchingDate?.status ?? null;
   return (
     <div
     className={`flex flex-col body_05 gap-6 hover:cursor-pointer text-center ${isSelected ? 'text-Grey_06' : 'text-Grey_03'}`}
@@ -34,7 +32,7 @@ function CalendarCell({day, selectedDate, setSelectedDate, matchingDate} : Props
       <div
         className={`absolute inset-0 flex items-center justify-center  ${isSelected ? 'text-white' : 'text-Grey_04'}`}
       >
-        {status=== "DONE" ? <CheckEmoji style={{ color: isSelected ? '#ffffff' : '#DADDE0', cursor: 'pointer' }} className="w-18 h-16 white"/> :count !==0 ? count : null }
+        {status === "DONE" ? <CheckEmoji style={{ color: isSelected ? '#ffffff' : '#DADDE0', cursor: 'pointer' }} className="w-18 h-16 white"/> :counts !==0 ? counts : null }
       </div>
     </div>
     <div>{day.format('D') + '일 '}</div>

--- a/src/pages/SchedulePage/Calendar/index.tsx
+++ b/src/pages/SchedulePage/Calendar/index.tsx
@@ -8,6 +8,7 @@ import nextBtn from '../../../assets/images/Calendar/nextWeekBtn.svg';
 
 import useWeeklyScheduleCountsQuery from '../../../hooks/useWeeklyScheduleCountsQuery';
 import CalendarCell from './CalendarCell';
+import { convertDateFormat } from '../../../utils';
 
 type WeeklyCalendarProps = {
   selectedDate: Dayjs;
@@ -57,9 +58,11 @@ const Calendar = ({
         </div>
         <div className={'flex place-content-between'}>
           {days.map((day, idx) => {
-            const matchingDate = weeklyScheduleMap.get(day);
+            const certainDay = convertDateFormat(day);
+            const matchingDate = weeklyScheduleMap.get(certainDay);
+
             return (
-                <CalendarCell key={idx} day={day} selectedDate={selectedDate} setSelectedDate={setSelectedDate} matchingDate = {matchingDate}  />
+                <CalendarCell key={idx} day={day} selectedDate={selectedDate} setSelectedDate={setSelectedDate} status={matchingDate?.status} counts={matchingDate?.counts} />
             );
           })}
         </div>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,6 +20,6 @@ export const getDailyDateObject = (date: Dayjs) => ({
 })
 
 export const getWeeklyDateObject = (date: Dayjs) => ({
-  start : date.format('YYYY-MM-DD'),
-  end : date.format('YYYY-MM-DD'),
+  start : date.startOf('week').format('YYYY-MM-DD'),
+  end : date.endOf('week').format('YYYY-MM-DD'),
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import dayjs, {Dayjs} from 'dayjs';
 
 export const convertDateFormat = (dateString: Dayjs) => {
-  return dayjs(dateString).format('YYYY-MM-DD');
+  return dayjs(dateString).format('YYYY-MM-DD').toString();
 };
 
 export const formatTime=(time: string) => {


### PR DESCRIPTION
## 📌 버그의 원인
`useHandleChecked` 훅은 일정 체크 여부를 토글한 뒤, 관련된 데이터를 최신 상태로 유지하기 위해 두 가지 쿼리를 무효화합니다.

- **SCHEDULE_QUERY_KEY.daily**: 선택한 날짜의 일정 데이터
- **SCHEDULE_QUERY_KEY.weekly**: 해당 주간의 남은 일정 수 데이터


```ts
export const useHandleChecked = ({dailyDate, weekRangeDate} : UseSchedulesProps) => {
  const queryClient = useQueryClient();

  return useMutation({
    mutationFn: async (scheduleId: number) => {
      await api.post(`/schedules/${scheduleId}/actions/toggle-checked`);
    },

    onSuccess: () => {
      queryClient.invalidateQueries({queryKey: SCHEDULE_QUERY_KEY.daily(dailyDate)})
      queryClient.invalidateQueries({queryKey: SCHEDULE_QUERY_KEY.weekly(weekRangeDate)})
    }
  })
}

```
그러나 아래와 같이 잘못된 쿼리 키로 invalidateQueries가 호출되고 있는 문제가 발견되었습니다.
daily와 weekly의 쿼리 키는 아래 이미지처럼 각각 `['SCHEDULE', 'DAILY', ...], ['SCHEDULE', 'WEEKLY', ...]` 형태를 가져야 합니다.

<img width="488" height="154" alt="스크린샷 2025-07-23 오후 3 54 01" src="https://github.com/user-attachments/assets/ec91eb4c-8c4d-4cbf-beba-2af17ec57275" />

그러나 실제로는 다음과 같이 **올바르지 않은 키 구조**로 무효화가 시도되고 있습니다.

<img width="780" height="89" alt="스크린샷 2025-07-23 오후 3 53 08" src="https://github.com/user-attachments/assets/82f4c2bc-133b-414d-bacb-9a3345117472" />
---

## ✅ 작업 내용
상위 컴포넌트에서 전달되는 selectedDate로 useHandleChecked의 weekRangeDate를 사용하고 있었습니다.

```ts
// 상위 컴포넌트 Calendar.ts
 const weeklyObj = getWeeklyDateObject(selectedDate);

//..중략
      <div className="flex flex-col gap-35 pt-40 pb-100">
            {scheduleList.map((schedule) => (
              <ScheduleDetail
                **weekRangeDate={weeklyObj}**
                onClick={() => onClickHandler(schedule.scheduleId)}
              />
            ))}
          </div>
```
```ts
// 직접 useHandledCheked 훅을 사용하는 Schedule.ts 
  const { mutate: toggleCheck } = useHandleChecked({ dailyDate, weekRangeDate });
```

```ts
export const getWeeklyDateObject = (date: Dayjs) => ({
  start : date.format('YYYY-MM-DD'),
  end : date.format('YYYY-MM-DD'),
})
```
그러나 weekRangeDate는 위와 같이 선택한 날짜에 대한 정보만 전달하고 있었습니다.

```ts
export const getWeeklyDateObject = (date: Dayjs) => ({
  start : date.startOf('week').format('YYYY-MM-DD'),
  end : date.endOf('week').format('YYYY-MM-DD'),
})
```
따라서 유틸 함수를 위와 같이 변경했습니다.

---

## 🧪 테스트 
<img width="778" height="89" alt="스크린샷 2025-07-23 오후 4 05 58" src="https://github.com/user-attachments/assets/28d851fe-2575-46ea-b54b-1519efbe4ea5" />

올바른 쿼리키가 들어갔습니다.

---

## ⚠️ 참고 사항

현재 dev 서버가 502 에러로 접근 불가하여, main 브랜치에 배포 후 확인이 필요합니다.  
만약 배포 후에도 동일한 증상이 발생한다면 다음과 같은 점들을 점검해야 합니다:
- `useMutation`의 `onSuccess` 콜백이 호출되지 않는 경우
- Query Key가 다시 정확하게 구성되지 않았을 가능성
- Schedule Count API에서 반환값이 갱신되지 않았을 가능성